### PR TITLE
Token HUD "Add portrait" button

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5,6 +5,8 @@
   "GINZZZUPORTRAITS": {
     "showCharacterPortrait": "Show Character",
     "hideCharacterPortrait": "Hide Character",
+    "tokenHUDShowPortrait": "Show Character",
+    "tokenHUDHidePortrait": "Hide Character",  
     "configurePortrait": "Configure portrait",
     "toggleCharacterPortrait": "Toggle Character",
     "showPanelUI": "Show Characters Panel",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -5,6 +5,8 @@
     "GINZZZUPORTRAITS": {
       "showCharacterPortrait": "Показать Персонажа",
       "hideCharacterPortrait": "Скрыть Персонажа",
+      "tokenHUDShowPortrait": "Показать Персонажа",
+      "tokenHUDHidePortrait": "Скрыть Персонажа",        
       "configurePortrait": "Настроить портрет",
       "toggleCharacterPortrait": "Переключить Персонажа",
       "showPanelUI": "Показать Панель Персонажей",

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -8,3 +8,4 @@ import "./features/portraits.js";
 import "./features/npcDock.js";
 import "./features/portraits-emotions.js";
 import "./features/tokenHudPortraitToggle.js";
+import "./features/playerPortraitToolbarToggle.js";

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -7,3 +7,4 @@ import "./features/custom-emotions.js";
 import "./features/portraits.js";
 import "./features/npcDock.js";
 import "./features/portraits-emotions.js";
+import "./features/tokenHudPortraitToggle.js";

--- a/scripts/features/playerPortraitToolbarToggle.js
+++ b/scripts/features/playerPortraitToolbarToggle.js
@@ -1,0 +1,86 @@
+// playerPortraitNearChatButton.js
+import { MODULE_ID, FLAG_PORTRAIT_SHOWN } from "../core/constants.js";
+
+function getLinkedCharacter() {
+  return game.user?.character ?? null;
+}
+
+function isShown(actor) {
+  return !!foundry.utils.getProperty(actor, FLAG_PORTRAIT_SHOWN);
+}
+
+async function toggleMyPortrait() {
+  const actor = getLinkedCharacter();
+  if (!actor) {
+    ui.notifications?.warn?.("No linked character assigned to your user.");
+    return;
+  }
+  if (!(game.user?.isGM || actor.isOwner)) {
+    ui.notifications?.warn?.("You don’t have permission to control this character.");
+    return;
+  }
+
+  const next = !isShown(actor);
+  await actor.update({ [FLAG_PORTRAIT_SHOWN]: next });
+}
+
+function upsertButton() {
+  // world setting gate
+  let enabled = true;
+  try { enabled = !!game.settings.get(MODULE_ID, "playerPortraitToolbarButton"); } catch (_) {}
+  if (!enabled) return;
+
+  // players only (как ты просил)
+  if (game.user?.isGM) return;
+
+  // Ищем уже существующую кнопку "глаз" (она создаётся в portraits.js)
+  const eyeBtn = document.getElementById("ginzzzu-portrait-ui-toggle-btn");
+  if (!eyeBtn) return;
+
+  // Не дублируем
+  if (document.getElementById("ginzzzu-player-portrait-toggle-btn")) return;
+
+  // Создаём кнопку
+  const btn = document.createElement("button");
+  btn.id = "ginzzzu-player-portrait-toggle-btn";
+  btn.className = "ginzzzu-portrait-btn ginzzzu-player-portrait-btn";
+  btn.style.pointerEvents = "auto";
+  btn.innerHTML = '<i class="fas fa-theater-masks" aria-hidden="true"></i>';
+
+  const actor = getLinkedCharacter();
+  const active = actor ? isShown(actor) : false;
+
+  // Tooltip (без новых переводов, раз ты сейчас не добавляешь их)
+  btn.title = game.i18n.localize(active ? "GINZZZUPORTRAITS.playerHidePortrait": "GINZZZUPORTRAITS.playerShowPortrait");
+  btn.setAttribute("aria-pressed", active ? "true" : "false");
+
+  btn.addEventListener("click", async (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    await toggleMyPortrait();
+
+    // обновим pressed/tooltip
+    const a = getLinkedCharacter();
+    const now = a ? isShown(a) : false;
+    btn.setAttribute("aria-pressed", now ? "true" : "false");
+    btn.title = game.i18n.localize(now ? "GINZZZUPORTRAITS.playerHidePortrait": "GINZZZUPORTRAITS.playerShowPortrait");
+    btn.classList.toggle("active", now);
+  });
+
+  // Вставляем рядом с глазом
+  eyeBtn.insertAdjacentElement("afterend", btn);
+}
+
+Hooks.once("ready", () => {
+  // Портретный HUD может создаться не мгновенно; сделаем несколько попыток
+  // (без таймеров в фоне — просто короткая серия)
+  let tries = 0;
+  const tick = () => {
+    tries += 1;
+    upsertButton();
+    if (!document.getElementById("ginzzzu-player-portrait-toggle-btn") && tries < 20) {
+      setTimeout(tick, 150);
+    }
+  };
+  tick();
+});

--- a/scripts/features/tokenHudPortraitToggle.js
+++ b/scripts/features/tokenHudPortraitToggle.js
@@ -1,0 +1,90 @@
+// tokenHudPortraitToggle.js
+import { MODULE_ID, FLAG_PORTRAIT_SHOWN } from "../core/constants.js";
+
+function canToggleForActor(actor) {
+  if (!actor) return false;
+
+  // По умолчанию — как у тебя сейчас: только GM (потому что togglePortrait у тебя GM-гейтит)
+  // Но чтобы не зависеть от внутренней проверки, продублируем:
+  if (game.user?.isGM) return true;
+
+  // Если захочешь разрешить владельцам — раскомментируй:
+  // return actor.isOwner;
+
+  return false;
+}
+
+function isPortraitShown(actor) {
+  try {
+    return !!foundry.utils.getProperty(actor, FLAG_PORTRAIT_SHOWN);
+  } catch {
+    return false;
+  }
+}
+
+function ensureButton(hud, html) {
+  // не дублируем кнопку при повторных рендерах
+  if (html[0]?.querySelector?.(".ginzzzu-tokenhud-portrait")) return;
+
+  const token = hud.object;               // Token (PlaceableObject)
+  const actor = token?.actor ?? token?.document?.actor;
+  if (!actor) return;
+  if (!canToggleForActor(actor)) return;
+
+  const shown = isPortraitShown(actor);
+
+  const titleKey = shown
+    ? "GINZZZUPORTRAITS.tokenHUDHidePortrait"
+    : "GINZZZUPORTRAITS.tokenHUDShowPortrait";
+
+  const $btn = $(`
+    <div class="control-icon ginzzzu-tokenhud-portrait ${shown ? "active" : ""}" role="button">
+      <i class="fas fa-theater-masks"></i>
+    </div>
+  `);
+
+  $btn.attr("title", game.i18n.localize(titleKey));
+
+  $btn.on("click", async (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+
+    const a = token?.actor ?? token?.document?.actor;
+    if (!a) return;
+
+    // Переключаем портрет актёра (вариант A)
+    await globalThis.GinzzzuPortraits?.togglePortrait?.(a);
+    globalThis.GinzzzuNPCDock?.rebuildMini?.();
+
+
+    // Обновим tooltip/active (быстро, без ожидания хуков)
+    const nowShown = isPortraitShown(a);
+    $btn.toggleClass("active", nowShown);
+    $btn.attr("title", game.i18n.localize(
+      nowShown ? "GINZZZUPORTRAITS.tokenHUDHidePortrait" : "GINZZZUPORTRAITS.tokenHUDShowPortrait"
+    ));
+  });
+
+  // Куда вставлять:
+  // Обычно справа — рядом с шестерёнкой/эффектами, но можно и слева.
+    const root = html instanceof HTMLElement ? html : html[0];
+    if (!root) return;
+
+    const rightCol = root.querySelector(".col.right");
+    if (rightCol) rightCol.prepend($btn[0]);
+    else root.append($btn[0]);
+}
+
+export function registerTokenHudPortraitToggle() {
+  Hooks.on("renderTokenHUD", (hud, html) => {
+    try {
+      ensureButton(hud, html);
+    } catch (e) {
+      console.error(`[${MODULE_ID}] TokenHUD portrait toggle failed`, e);
+    }
+  });
+}
+
+Hooks.once("ready", () => {
+  registerTokenHudPortraitToggle();
+});

--- a/scripts/features/tokenHudPortraitToggle.js
+++ b/scripts/features/tokenHudPortraitToggle.js
@@ -1,6 +1,11 @@
 // tokenHudPortraitToggle.js
 import { MODULE_ID, FLAG_PORTRAIT_SHOWN } from "../core/constants.js";
 
+function getWorldActorFromToken(token) {
+  const actorId = token?.document?.actorId ?? token?.actor?.id;
+  return actorId ? (game.actors?.get(actorId) ?? token?.actor ?? null) : (token?.actor ?? null);
+}
+
 function canToggleForActor(actor) {
   if (!actor) return false;
 
@@ -27,7 +32,7 @@ function ensureButton(hud, html) {
   if (html[0]?.querySelector?.(".ginzzzu-tokenhud-portrait")) return;
 
   const token = hud.object;               // Token (PlaceableObject)
-  const actor = token?.actor ?? token?.document?.actor;
+  const actor = getWorldActorFromToken(token);
   if (!actor) return;
   if (!canToggleForActor(actor)) return;
 
@@ -49,7 +54,7 @@ function ensureButton(hud, html) {
     ev.preventDefault();
     ev.stopPropagation();
 
-    const a = token?.actor ?? token?.document?.actor;
+  const a = getWorldActorFromToken(token);
     if (!a) return;
 
     // Переключаем портрет актёра (вариант A)

--- a/styles/portraits.css
+++ b/styles/portraits.css
@@ -195,3 +195,57 @@ body:has(#sidebar-content.expanded):has(#sidebar-tab-chat:not(.active)):has(#cha
 #ginzzzu-portrait-ui-toggle-btn i {
   font-size: 14px;
 }
+
+/* === Player portrait toggle (masks) — stacked above the eye button === */
+#ginzzzu-player-portrait-toggle-btn {
+  position: fixed;
+  /* Same horizontal position rules as the eye button */
+  left: calc(100vw - var(--left-sidebar-width) - var(--sidebar-width) - var(--button-width));
+  transform: none;
+  z-index: 100501; /* a bit above the eye */
+  pointer-events: auto;
+
+  /* Place above the eye: bottom(eye) + height(eye) + gap */
+  bottom: calc(18px + 28px + 6px);
+
+  /* Match eye button styling */
+  background: rgba(0,0,0,0.35);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.15);
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  min-width: 36px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
+  transition: background-color 0.2s ease, transform 120ms ease, left 0.3s ease-in-out;
+}
+
+/* Mirror the same responsive positioning rules as the eye button */
+body:has(#sidebar-content:not(.expanded)) #ginzzzu-player-portrait-toggle-btn {
+  left: calc(100vw - var(--left-sidebar-width) - var(--button-width));
+}
+body:has(#sidebar-content:not(.expanded)):has(#chat-notifications:not(.input-hidden)) #ginzzzu-player-portrait-toggle-btn {
+  left: calc(100vw - var(--left-sidebar-width) - var(--quick-chat-width) - var(--button-width) - 18px);
+}
+body:has(#sidebar-content.expanded):has(#chat-notifications:not(.input-hidden)) #ginzzzu-player-portrait-toggle-btn {
+  left: calc(100vw - var(--left-sidebar-width) - var(--sidebar-width) - var(--quick-chat-width) - var(--button-width) - 16px);
+}
+body:has(#sidebar-content.expanded.active-chat):has(#chat-notifications:not(.input-hidden)) #ginzzzu-player-portrait-toggle-btn {
+  left: calc(100vw - var(--sidebar-width) - 48px + 8px);
+}
+body:has(#sidebar-content.expanded):has(#sidebar-tab-chat:not(.active)):has(#chat-notifications.input-hidden) #ginzzzu-player-portrait-toggle-btn {
+  left: calc(100vw - var(--left-sidebar-width) - var(--sidebar-width) - var(--button-width) - var(--extra-buttons-width));
+}
+
+#ginzzzu-player-portrait-toggle-btn:hover {
+  transform: translateY(-2px);
+  background: rgba(0,0,0,0.5);
+}
+
+#ginzzzu-player-portrait-toggle-btn i {
+  font-size: 14px;
+}


### PR DESCRIPTION
You can now show or hide an actor’s portrait directly from the Token HUD on the scene.
A new button in the token controls allows the GM to toggle the portrait without opening the portrait dock, making it faster to manage active portraits during play.